### PR TITLE
Fix wrong api baseUrl

### DIFF
--- a/src/Utils/Api.js
+++ b/src/Utils/Api.js
@@ -21,10 +21,10 @@ export default function () {
     if (process.env.NODE_ENV === "development") {
         const url = "https://staging-carpal.herokuapp.com/";
         return axiosInstance("development", url);
-    } else if (process.env.NODE_ENV === "production") {
+    } else if (process.env.NODE_ENV === "production" || process_env.REACT_APP_IS_STAGING === 0) {
         const url = "https://carpal-production.herokuapp.com/";
         return axiosInstance("production", url);
-    } else if (process.env.NODE_ENV === "staging") {
+    } else if (process_env.REACT_APP_IS_STAGING === 1) {
         const url = "https://staging-carpal.herokuapp.com/";
         return axiosInstance("development", url);
     }


### PR DESCRIPTION
create-react-app sets node_env to production when using `npm build` regardless of what we set. Using a different env for staging to work around this issue.

# Description

fixes https://github.com/Lambda-School-Labs/carpal-fe/issues/71

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

-   [ ] Complete, tested, ready to review and merge
-   [x] Complete, but not tested (may need new tests)
-   [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

-   [ ] Test A
-   [ ] Test B

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] My code has been reviewed by at least one peer
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
-   [x] There are no merge conflicts
